### PR TITLE
feat: add job to notify slack about fail in master

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,3 +6,5 @@ description: >
 display:
   source_url: "https://github.com/FigurePOS/circle-ci-node-ecs-orb"
 
+orbs:
+  slack: circleci/slack@4.12.5

--- a/src/examples/slack_notify_fail_master.yml
+++ b/src/examples/slack_notify_fail_master.yml
@@ -1,0 +1,19 @@
+description: >
+  notify slack about fail after merge to master
+
+usage:
+  version: 2.1
+  orbs:
+    node-ecs: figure/node-ecs@1.5.0
+
+  jobs:
+    deploy_development:
+      executor: node-ecs/node20
+      steps:
+        - checkout
+        - run:
+            name: "Deploy DEVELOPMENT"
+            command: |
+              ./scripts/deploy.sh ${version:-${CIRCLE_SHA1:0:7}} 880892332156 development "fgr-service-business-config" "true" "/business-config"
+        - node-ecs/slack_notify_fail_master:
+            service_name: "fgr-service-business-config"

--- a/src/jobs/slack_notify_fail_master.yml
+++ b/src/jobs/slack_notify_fail_master.yml
@@ -1,0 +1,39 @@
+description: >
+  notify slack about fail after merge to master
+
+executor: node20
+
+parameters:
+  service_name:
+    type: string
+    description: "Service Name"
+
+steps:
+  - slack/notify:
+      branch_pattern: master
+      event: fail
+      custom: |
+        {
+          "blocks": [
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": ":interrobang: *<<parameters.service_name>>*: Execution of job `${CIRCLE_JOB}` failed (`${CIRCLE_SHA1:0:7}`) :interrobang:"
+              }
+            },
+            {
+              "type": "actions",
+              "elements": [
+                {
+                  "type": "button",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "View Job"
+                  },
+                  "url": "${CIRCLE_BUILD_URL}"
+                }
+              ]
+            }
+          ]
+        }


### PR DESCRIPTION
Namísto 

```yaml
- slack/notify:
    *slack_notification
```

a https://github.com/FigurePOS/fgr-service-business-config/blob/5cc050774b9aa0ccb159c855936952dbcce15f27/.circleci/config.yml#L3-L30

Se bude psát 

```yaml
- node-ecs/slack_notify_fail_master:
    service_name: "fgr-service-business-config"
```