### PR TITLE
fix: setting budy url

### DIFF
--- a/src/commands/buddy_notify_deploy.yml
+++ b/src/commands/buddy_notify_deploy.yml
@@ -6,7 +6,8 @@ parameters:
     type: string
     description: "Service Name"
   trigger_url:
-    type: string
+    type: env_var_name
+    default: FIGURE_BUDDY_TRIGGER_URL
     description: "Trigger URL"
 
 steps:
@@ -14,5 +15,5 @@ steps:
       name: Notify buddy about deployment
       environment:
         SERVICE_NAME: <<parameters.service_name>>
-        TRIGGER_URL: <<parameters.trigger_url>>
+        FIGURE_BUDDY_TRIGGER_URL: <<parameters.trigger_url>>
       command: <<include(scripts/buddy-notify-deploy.sh)>>

--- a/src/scripts/buddy-notify-deploy.sh
+++ b/src/scripts/buddy-notify-deploy.sh
@@ -18,9 +18,9 @@ then
       exit 1
 fi
 
-if [ -z "$TRIGGER_URL" ]
+if [ -z "$FIGURE_BUDDY_TRIGGER_URL" ]
 then
-      echo "TRIGGER_URL variable is empty"
+      echo "FIGURE_BUDDY_TRIGGER_URL variable is empty"
       exit 1
 fi
 
@@ -31,6 +31,6 @@ curl \
     -X POST \
     -H "Content-type: application/json" \
     --data "{\"type\":\"dev-deployed\",\"service_name\":\"$SERVICE_NAME\",\"commit_message\":\"$commit_message\",\"workflow_id\":\"$CIRCLE_WORKFLOW_ID\"}" \
-    "$TRIGGER_URL"
+    "$FIGURE_BUDDY_TRIGGER_URL"
 
 echo "SUCCESS"


### PR DESCRIPTION
Hm, tak ono nejde předávat env var jako parametr jobu. 🙈 
![CleanShot 2023-08-15 at 11 14 09@2x](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/3cf348b8-684d-4faa-a376-00b7c43ac99d)

Tak jinak, ten `type: env_var_name` říká že se má hodnota parametru vzít z env vproměnné danýho názvu, defaultně  `FIGURE_BUDDY_TRIGGER_URL`. Takže tam nebude třeba ten parametr nakonec ani zadávat když je ta env var v každý pipelině stejná.