### PR TITLE
fix: add command for slack_notify_fail_master

### DIFF
--- a/src/commands/slack_notify_fail_master.yml
+++ b/src/commands/slack_notify_fail_master.yml
@@ -1,0 +1,37 @@
+description: >
+  notify slack about fail after merge to master
+
+parameters:
+  service_name:
+    type: string
+    description: "Service Name"
+
+steps:
+  - slack/notify:
+      branch_pattern: master
+      event: fail
+      custom: |
+        {
+          "blocks": [
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": ":interrobang: *<<parameters.service_name>>*: Execution of job `${CIRCLE_JOB}` failed (`${CIRCLE_SHA1:0:7}`) :interrobang:"
+              }
+            },
+            {
+              "type": "actions",
+              "elements": [
+                {
+                  "type": "button",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "View Job"
+                  },
+                  "url": "${CIRCLE_BUILD_URL}"
+                }
+              ]
+            }
+          ]
+        }

--- a/src/jobs/slack_notify_fail_master.yml
+++ b/src/jobs/slack_notify_fail_master.yml
@@ -9,31 +9,5 @@ parameters:
     description: "Service Name"
 
 steps:
-  - slack/notify:
-      branch_pattern: master
-      event: fail
-      custom: |
-        {
-          "blocks": [
-            {
-              "type": "section",
-              "text": {
-                "type": "mrkdwn",
-                "text": ":interrobang: *<<parameters.service_name>>*: Execution of job `${CIRCLE_JOB}` failed (`${CIRCLE_SHA1:0:7}`) :interrobang:"
-              }
-            },
-            {
-              "type": "actions",
-              "elements": [
-                {
-                  "type": "button",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "View Job"
-                  },
-                  "url": "${CIRCLE_BUILD_URL}"
-                }
-              ]
-            }
-          ]
-        }
+  - slack_notify_fail_master:
+      service_name: <<parameters.service_name>>


### PR DESCRIPTION
Ach jo, tak ještě jeden problémek. Logika musí být v `commandu` a ne v `jobu`. Obdobně je to v
https://github.com/FigurePOS/circle-ci-terraform-orb/blob/d9739fbfa6a3acc9a0de03293e057a972b54c01e/src/jobs/buddy_notify_deploy.yml#L14-L17
a https://github.com/FigurePOS/circle-ci-terraform-orb/blob/d9739fbfa6a3acc9a0de03293e057a972b54c01e/src/commands/buddy_notify_deploy.yml#L13-L19
