### PR TITLE
fix: passing url to buddy slack command

### DIFF
--- a/src/commands/buddy_notify_deploy.yml
+++ b/src/commands/buddy_notify_deploy.yml
@@ -6,8 +6,8 @@ parameters:
     type: string
     description: "Service Name"
   trigger_url:
-    type: env_var_name
-    default: FIGURE_BUDDY_TRIGGER_URL
+    type: string
+    default: ${FIGURE_BUDDY_TRIGGER_URL}
     description: "Trigger URL"
 
 steps:
@@ -15,5 +15,5 @@ steps:
       name: Notify buddy about deployment
       environment:
         SERVICE_NAME: <<parameters.service_name>>
-        FIGURE_BUDDY_TRIGGER_URL: <<parameters.trigger_url>>
+        TRIGGER_URL: <<parameters.trigger_url>>
       command: <<include(scripts/buddy-notify-deploy.sh)>>

--- a/src/jobs/buddy_notify_deploy.yml
+++ b/src/jobs/buddy_notify_deploy.yml
@@ -9,6 +9,7 @@ parameters:
     description: "Service Name"
   trigger_url:
     type: string
+    default: ${FIGURE_BUDDY_TRIGGER_URL}
     description: "Trigger URL"
 
 steps:


### PR DESCRIPTION
Tak jo no. Jsem to už i předem vyzkoušel že to opravdu předává hodnotu tý env proměnný, takže by to mohlo konečně fungovat:

![CleanShot 2023-08-15 at 15 00 51@2x](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/260c9ba0-b53e-4d64-8228-29c064b13658)
