### PR TITLE
fix: service name in notification jobs FGR3-2332

### DIFF
--- a/src/commands/buddy_notify_deploy.yml
+++ b/src/commands/buddy_notify_deploy.yml
@@ -4,6 +4,7 @@ description: >
 parameters:
   service_name:
     type: string
+    default: ${CIRCLE_PROJECT_REPONAME}
     description: "Service Name"
   trigger_url:
     type: string

--- a/src/commands/slack_notify_fail_master.yml
+++ b/src/commands/slack_notify_fail_master.yml
@@ -4,6 +4,7 @@ description: >
 parameters:
   service_name:
     type: string
+    default: ${CIRCLE_PROJECT_REPONAME}
     description: "Service Name"
 
 steps:

--- a/src/examples/buddy_notify_deploy.yml
+++ b/src/examples/buddy_notify_deploy.yml
@@ -16,5 +16,4 @@ usage:
             command: |
               ./scripts/deploy.sh ${version:-${CIRCLE_SHA1:0:7}} 880892332156 development "fgr-service-business-config" "true" "/business-config"
         - node-ecs/buddy_notify_deploy:
-            service_name: "fgr-service-business-config"
             trigger_url: $FIGURE_BUDDY_TRIGGER_URL

--- a/src/examples/slack_notify_fail_master.yml
+++ b/src/examples/slack_notify_fail_master.yml
@@ -15,5 +15,4 @@ usage:
             name: "Deploy DEVELOPMENT"
             command: |
               ./scripts/deploy.sh ${version:-${CIRCLE_SHA1:0:7}} 880892332156 development "fgr-service-business-config" "true" "/business-config"
-        - node-ecs/slack_notify_fail_master:
-            service_name: "fgr-service-business-config"
+        - node-ecs/slack_notify_fail_master

--- a/src/jobs/buddy_notify_deploy.yml
+++ b/src/jobs/buddy_notify_deploy.yml
@@ -6,6 +6,7 @@ executor: node20
 parameters:
   service_name:
     type: string
+    default: ${CIRCLE_PROJECT_REPONAME}
     description: "Service Name"
   trigger_url:
     type: string

--- a/src/jobs/slack_notify_fail_master.yml
+++ b/src/jobs/slack_notify_fail_master.yml
@@ -6,6 +6,7 @@ executor: node20
 parameters:
   service_name:
     type: string
+    default: ${CIRCLE_PROJECT_REPONAME}
     description: "Service Name"
 
 steps:


### PR DESCRIPTION
CircleCI nezvládne z nějakýho důvodu expandovat tu env var když se zadá takto:
```yaml
- node-ecs/slack_notify_fail_master:
          service_name: $CIRCLE_PROJECT_REPONAME
```

![image](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/73b6ea55-86e9-488b-8dcd-b4edb12bdf85)
 

Nastavil jsem to podle https://github.com/FigurePOS/circle-ci-node-ecs-orb/blob/5c6156e58406a73cac797eafd6c69bbf25db8888/src/commands/buddy_notify_deploy.yml#L9-L11

Tak se to z tý env var vezme defaultně a nebude se muset zadávat v pipelině, takže se bude psát jen:
```yaml
- node-ecs/slack_notify_fail_master
```
bez parametrů