### PR TITLE
fix: pass env parameter to assess plan change command FGR3-2347

### DIFF
--- a/src/commands/terraform_assess_plan_changed.yml
+++ b/src/commands/terraform_assess_plan_changed.yml
@@ -11,4 +11,6 @@ steps:
       at: /tmp/workspace
   - run:
       name: Assess Plan Change
+      environment:
+        ENV: <<parameters.env>>
       command: <<include(scripts/cancel-workflow.sh)>>


### PR DESCRIPTION
Tak ještě mi tam chybělo předání parametru https://github.com/FigurePOS/circle-ci-terraform-orb/blob/73da7ed1e53facad68ae2ae1a42277f80c5e8b5b/src/commands/terraform_assess_plan_changed.yml#L5-L7 do env var https://github.com/FigurePOS/circle-ci-terraform-orb/blob/73da7ed1e53facad68ae2ae1a42277f80c5e8b5b/src/scripts/cancel-workflow.sh#L22