### PR TITLE
feat: pass ssh key fingerprint to tf jobs FGR3-2347

### DIFF
--- a/src/commands/terraform_deploy.yml
+++ b/src/commands/terraform_deploy.yml
@@ -16,8 +16,15 @@ parameters:
   env:
     type: string
     description: "Environment"
+  ssh_key_fingerprint:
+    type: string
+    default: ""
+    description: "SSH Key Fingerprint"
 
 steps:
+  - add_ssh_keys:
+      fingerprints:
+        - <<parameters.ssh_key_fingerprint>>
   - run:
       name: Terraform Init
       environment:

--- a/src/commands/terraform_plan.yml
+++ b/src/commands/terraform_plan.yml
@@ -16,8 +16,15 @@ parameters:
   env:
     type: string
     description: "Environment"
+  ssh_key_fingerprint:
+    type: string
+    default: ""
+    description: "SSH Key Fingerprint"
 
 steps:
+  - add_ssh_keys:
+      fingerprints:
+        - <<parameters.ssh_key_fingerprint>>
   - run:
       name: Terraform Init
       environment:

--- a/src/commands/terraform_validate.yml
+++ b/src/commands/terraform_validate.yml
@@ -16,8 +16,15 @@ parameters:
   env:
     type: string
     description: "Environment"
+  ssh_key_fingerprint:
+    type: string
+    default: ""
+    description: "SSH Key Fingerprint"
 
 steps:
+  - add_ssh_keys:
+      fingerprints:
+        - <<parameters.ssh_key_fingerprint>>
   - run:
       name: Terraform Init
       environment:

--- a/src/jobs/terraform_deploy.yml
+++ b/src/jobs/terraform_deploy.yml
@@ -18,6 +18,10 @@ parameters:
   env:
     type: string
     description: "Environment"
+  ssh_key_fingerprint:
+    type: string
+    default: ""
+    description: "SSH Key Fingerprint"
 
 steps:
   - terraform_deploy:
@@ -25,3 +29,4 @@ steps:
       account_id: <<parameters.account_id>>
       dir: <<parameters.dir>>
       env: <<parameters.env>>
+      ssh_key_fingerprint: <<parameters.ssh_key_fingerprint>>

--- a/src/jobs/terraform_plan.yml
+++ b/src/jobs/terraform_plan.yml
@@ -18,6 +18,10 @@ parameters:
   env:
     type: string
     description: "Environment"
+  ssh_key_fingerprint:
+    type: string
+    default: ""
+    description: "SSH Key Fingerprint"
 
 steps:
   - terraform_plan:
@@ -25,3 +29,4 @@ steps:
       bucket_name: <<parameters.bucket_name>>
       dir: <<parameters.dir>>
       env: <<parameters.env>>
+      ssh_key_fingerprint: <<parameters.ssh_key_fingerprint>>

--- a/src/jobs/terraform_validate.yml
+++ b/src/jobs/terraform_validate.yml
@@ -18,10 +18,15 @@ parameters:
   env:
     type: string
     description: "Environment"
+  ssh_key_fingerprint:
+    type: string
+    default: ""
+    description: "SSH Key Fingerprint"
 
 steps:
   - terraform_validate:
-      account_id: << parameters.account_id >>
+      account_id: <<parameters.account_id>>
       bucket_name: <<parameters.bucket_name>>
-      dir: << parameters.dir >>
-      env: << parameters.env >>
+      dir: <<parameters.dir>>
+      env: <<parameters.env>>
+      ssh_key_fingerprint: <<parameters.ssh_key_fingerprint>>

--- a/workflows/tf.yml
+++ b/workflows/tf.yml
@@ -8,6 +8,10 @@ parameters:
   service_name:
     type: string
     default: "service"
+  ssh_key_fingerprint:
+    type: string
+    default: ""
+    description: "SSH Key Fingerprint"
 
 workflows:
   terraform_validation_deploy:
@@ -59,8 +63,9 @@ jobs:
       - node-ecs/terraform_plan:
           account_id: "880892332156"
           env: development
+          ssh_key_fingerprint: <<pipeline.parameters.ssh_key_fingerprint>>
       - node-ecs/slack_notify_fail_master:
-          service_name: << pipeline.parameters.service_name >>
+          service_name: <<pipeline.parameters.service_name>>
 
   terraform_validate:
     description: "Terraform Validation"
@@ -70,8 +75,9 @@ jobs:
       - node-ecs/terraform_validate:
           account_id: "880892332156"
           env: development
+          ssh_key_fingerprint: <<pipeline.parameters.ssh_key_fingerprint>>
       - node-ecs/slack_notify_fail_master:
-          service_name: << pipeline.parameters.service_name >>
+          service_name: <<pipeline.parameters.service_name>>
 
   terraform_deploy_dev:
     description: "Terraform Deployment to Development"
@@ -81,8 +87,9 @@ jobs:
       - node-ecs/terraform_deploy:
           account_id: "880892332156"
           env: development
+          ssh_key_fingerprint: <<pipeline.parameters.ssh_key_fingerprint>>
       - node-ecs/slack_notify_fail_master:
-          service_name: << pipeline.parameters.service_name >>
+          service_name: <<pipeline.parameters.service_name>>
 
   terraform_plan_prod:
     description: "Terraform Plan for Production"
@@ -92,8 +99,9 @@ jobs:
       - node-ecs/terraform_plan:
           account_id: "682919404744"
           env: production
+          ssh_key_fingerprint: <<pipeline.parameters.ssh_key_fingerprint>>
       - node-ecs/slack_notify_fail_master:
-          service_name: << pipeline.parameters.service_name >>
+          service_name: <<pipeline.parameters.service_name>>
 
   terraform_deploy_prod:
     description: "Terraform Deployment to Production"
@@ -103,5 +111,6 @@ jobs:
       - node-ecs/terraform_deploy:
           account_id: "682919404744"
           env: production
+          ssh_key_fingerprint: <<pipeline.parameters.ssh_key_fingerprint>>
       - node-ecs/slack_notify_fail_master:
-          service_name: << pipeline.parameters.service_name >>
+          service_name: <<pipeline.parameters.service_name>>


### PR DESCRIPTION
Některý pipeliny (orders a make-it-butter-api) dělají ssh tunel na bastion a potřebují k tomu ssh klíč (https://github.com/FigurePOS/fgr-service-orders/blob/3b538e975d7127233647013d591f02082240970a/.circleci/config.yml#L123-L125)

Vyzkoušel jsem, že to nevyfailuje když se tomu `add_ssh_keys` commandu předá prázdný řetězec pro ty pipeliny který to nepotřebují, tak se jen nastaví nebo nenastaví `ssh_key_fingerprint`parametr a mělo by to fungovat všude.
![CleanShot 2023-08-31 at 15 28 57](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/f65103eb-e771-46d0-badd-78facf1efc4f)
