### PR TITLE
feat: allow running db tunnel in tf init FGR3-2347

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -26,8 +26,10 @@ jobs:
       - checkout
       - node-ecs/terraform_plan:
           account_id: "880892332156"
+          db_tunnel_mapping: "5432:main_database_host"
           dir: test
           env: development
+          ssh_key_fingerprint: "82:27:10:3f:4c:a3:c5:8c:7e:6a:f3:a3:b6:dc:1e:79"
 
   test-terraform_validate:
     executor: node-ecs/node20
@@ -44,19 +46,21 @@ jobs:
       - checkout
       - node-ecs/terraform_deploy:
           account_id: "880892332156"
+          db_tunnel_mapping: "5432:main_database_host"
           dir: test
           env: development
+          ssh_key_fingerprint: "82:27:10:3f:4c:a3:c5:8c:7e:6a:f3:a3:b6:dc:1e:79"
 
 workflows:
   test-deploy:
     jobs:
-      - test-terraform_plan:
-          context: node
-          filters: *filters
       - test-terraform_validate:
           context: node
+          filters: *filters
+      - test-terraform_plan:
+          context: node
           requires:
-            - test-terraform_plan
+            - test-terraform_validate
           filters: *filters
       - test-terraform_deploy:
           context: node

--- a/src/commands/terraform_deploy.yml
+++ b/src/commands/terraform_deploy.yml
@@ -9,6 +9,10 @@ parameters:
     type: string
     description: "Name of S3 Bucket with terraform state"
     default: ""
+  db_tunnel_mapping:
+    type: string
+    default: ""
+    description: "Mapping of ports to hostnames stored in SSM in format: port:ssm_param,port:ssm_param"
   dir:
     type: string
     default: "tf"
@@ -37,23 +41,14 @@ steps:
         SCRIPT_SET_VARS: <<include(scripts/set-variables.sh)>>
       command: <<include(scripts/terraform-init.sh)>>
   - run:
-      name: Terraform Plan
-      environment:
-        AWS_ACCESS_KEY_ID: ""
-        AWS_SECRET_ACCESS_KEY: ""
-        DIR: <<parameters.dir>>
-        ENV: <<parameters.env>>
-        TF_VAR_aws_account_id: <<parameters.account_id>>
-        TF_VAR_aws_profile: "assumed-role"
-        TF_VAR_env: <<parameters.env>>
-      command: <<include(scripts/terraform-plan.sh)>>
-  - run:
       name: Terraform Deploy
       environment:
         AWS_ACCESS_KEY_ID: ""
         AWS_SECRET_ACCESS_KEY: ""
+        DB_TUNNEL_MAPPING: <<parameters.db_tunnel_mapping>>
         DIR: <<parameters.dir>>
         ENV: <<parameters.env>>
+        SCRIPT_SSH_TUNNEL: <<include(scripts/ssh-tunnel.sh)>>
         TF_VAR_aws_account_id: <<parameters.account_id>>
         TF_VAR_aws_profile: "assumed-role"
         TF_VAR_env: <<parameters.env>>

--- a/src/commands/terraform_plan.yml
+++ b/src/commands/terraform_plan.yml
@@ -9,6 +9,10 @@ parameters:
     type: string
     description: "Name of S3 Bucket with terraform state"
     default: ""
+  db_tunnel_mapping:
+    type: string
+    default: ""
+    description: "Mapping of ports to hostnames stored in SSM in format: port:ssm_param,port:ssm_param"
   dir:
     type: string
     default: "tf"
@@ -41,8 +45,10 @@ steps:
       environment:
         AWS_ACCESS_KEY_ID: ""
         AWS_SECRET_ACCESS_KEY: ""
+        DB_TUNNEL_MAPPING: <<parameters.db_tunnel_mapping>>
         DIR: <<parameters.dir>>
         ENV: <<parameters.env>>
+        SCRIPT_SSH_TUNNEL: <<include(scripts/ssh-tunnel.sh)>>
         TF_VAR_aws_account_id: <<parameters.account_id>>
         TF_VAR_aws_profile: "assumed-role"
         TF_VAR_env: <<parameters.env>>

--- a/src/scripts/ssh-tunnel.sh
+++ b/src/scripts/ssh-tunnel.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [ -n "$DB_TUNNEL_MAPPING" ]
+then
+      SSH_CMD="ssh -v -4 -N -o StrictHostKeyChecking=no"
+
+      # $DB_TUNNEL_MAPPING has form of "port1:param1:port2:param2"
+      IFS=',' read -ra MAPPING <<< "$DB_TUNNEL_MAPPING"
+      for i in "${MAPPING[@]}"; do
+            IFS=':' read -ra PARTS <<< "$i"
+            PORT=${PARTS[0]}
+            PARAM=${i#"$PORT":}
+
+            URL=$(aws ssm get-parameters --names "$PARAM" --region=us-east-1 --query 'Parameters[].Value' --output text --profile assumed-role)
+            # shellcheck disable=SC2181
+            if [ $? -ne 0 ]; then
+                  echo "Error getting parameter $PARAM"
+                  exit 1
+            fi
+
+            SSH_CMD="$SSH_CMD -L $PORT:$URL:5432"
+      done
+
+      BASTION_URL=$(aws ssm get-parameters --names "bastion_endpoint" --region=us-east-1 --query 'Parameters[].Value' --output text --profile assumed-role)
+      SSH_CMD="$SSH_CMD ec2-user@$BASTION_URL"
+
+      echo "Running $SSH_CMD"
+      $SSH_CMD &
+      sleep 1
+else
+      echo "DB_TUNNEL_MAPPING is empty, no tunnel created."
+fi

--- a/src/scripts/terraform-deploy.sh
+++ b/src/scripts/terraform-deploy.sh
@@ -12,11 +12,14 @@ then
       exit 1
 fi
 
+if [ -z "$SCRIPT_SSH_TUNNEL" ]
+then
+      echo "SCRIPT_SSH_TUNNEL is empty"
+      exit 1
+fi
+
+eval "$SCRIPT_SSH_TUNNEL"
+
 cd "$DIR" || exit
 
-if [ -f /tmp/"$ENV"-tfplan.binary ];
-then
-    terraform apply --auto-approve /tmp/"$ENV"-tfplan.binary;
-else
-    echo "No plan found."
-fi
+terraform apply --auto-approve

--- a/src/scripts/terraform-init.sh
+++ b/src/scripts/terraform-init.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if [ -z "$DIR" ]
 then

--- a/src/scripts/terraform-plan.sh
+++ b/src/scripts/terraform-plan.sh
@@ -12,6 +12,14 @@ then
       exit 1
 fi
 
+if [ -z "$SCRIPT_SSH_TUNNEL" ]
+then
+      echo "SCRIPT_SSH_TUNNEL is empty"
+      exit 1
+fi
+
+eval "$SCRIPT_SSH_TUNNEL"
+
 cd "$DIR" || exit
 
 if terraform plan -detailed-exitcode --out /tmp/"$ENV"-tfplan.binary;
@@ -19,6 +27,11 @@ then
     rm -rf /tmp/"$ENV"-tfplan.binary
     echo "No changes detected."
 else
+    if $? -eq 2;
+    then
+        echo "Error running terraform plan"
+        exit 1
+    fi
     terraform show -json /tmp/"$ENV"-tfplan.binary > /tmp/"$ENV"-tfplan.json
 fi
 

--- a/test/main.tf
+++ b/test/main.tf
@@ -2,7 +2,7 @@
 terraform {
   backend "s3" {
     region = "us-east-1"
-    key = "circle-ci-terraform-orb/terraform.tfstate"
+    key    = "circle-ci-terraform-orb/terraform.tfstate"
   }
 
   required_providers {
@@ -12,12 +12,32 @@ terraform {
     datadog = {
       source = "datadog/datadog"
     }
+
+    postgresql = {
+      source = "cyrilgdn/postgresql"
+    }
   }
 }
 
 provider "aws" {
-  region = var.region
+  region  = var.region
   profile = var.aws_profile
+}
+
+provider "postgresql" {
+  alias           = "main"
+  host            = "localhost"
+  port            = 5432
+  database        = "postgres"
+  username        = "twbrds"
+  password        = data.aws_ssm_parameter.postgres_main_root_password.value
+  superuser       = false
+  sslmode         = "require"
+  connect_timeout = 15
+}
+
+data "aws_ssm_parameter" "postgres_main_root_password" {
+  name = "secret.service.orders.postgres_main_root_password"
 }
 
 variable "aws_profile" {}

--- a/test/sample.tf
+++ b/test/sample.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "log_group" {
-  name = "/test/circle-ci-node-ecs-orb"
+  name              = "/test/circle-ci-node-ecs-orb"
   retention_in_days = 400
 }
 
@@ -9,4 +9,20 @@ resource "datadog_metric_metadata" "request_time" {
   description = "99th percentile request time in millseconds"
   type        = "gauge"
   unit        = "millisecond"
+}
+
+resource "postgresql_function" "orb_ci_test_function" {
+  provider = postgresql.main
+  name     = "orb_ci_test_function"
+  arg {
+    name = "i"
+    type = "integer"
+  }
+  returns  = "integer"
+  language = "plpgsql"
+  body     = <<-EOF
+        BEGIN
+            RETURN i + 1;
+        END;
+    EOF
 }

--- a/workflows/tf.yml
+++ b/workflows/tf.yml
@@ -5,6 +5,10 @@ orbs:
   node-ecs: figure/node-ecs@1.11.2
 
 parameters:
+  db_tunnel_mapping:
+    type: string
+    default: ""
+    description: "Mapping of ports to hostnames stored in SSM in format: port:ssm_param,port:ssm_param"
   service_name:
     type: string
     default: "service"
@@ -62,6 +66,7 @@ jobs:
       - checkout
       - node-ecs/terraform_plan:
           account_id: "880892332156"
+          db_tunnel_mapping: <<pipeline.parameters.db_tunnel_mapping>>
           env: development
           ssh_key_fingerprint: <<pipeline.parameters.ssh_key_fingerprint>>
       - node-ecs/slack_notify_fail_master:
@@ -86,6 +91,7 @@ jobs:
       - checkout
       - node-ecs/terraform_deploy:
           account_id: "880892332156"
+          db_tunnel_mapping: <<pipeline.parameters.db_tunnel_mapping>>
           env: development
           ssh_key_fingerprint: <<pipeline.parameters.ssh_key_fingerprint>>
       - node-ecs/slack_notify_fail_master:
@@ -98,6 +104,7 @@ jobs:
       - checkout
       - node-ecs/terraform_plan:
           account_id: "682919404744"
+          db_tunnel_mapping: <<pipeline.parameters.db_tunnel_mapping>>
           env: production
           ssh_key_fingerprint: <<pipeline.parameters.ssh_key_fingerprint>>
       - node-ecs/slack_notify_fail_master:
@@ -110,6 +117,7 @@ jobs:
       - checkout
       - node-ecs/terraform_deploy:
           account_id: "682919404744"
+          db_tunnel_mapping: <<pipeline.parameters.db_tunnel_mapping>>
           env: production
           ssh_key_fingerprint: <<pipeline.parameters.ssh_key_fingerprint>>
       - node-ecs/slack_notify_fail_master:


### PR DESCRIPTION
V případě, že se do piepliny zadá parametr `db_tunnel_mapping`, tak se nastartuje ssh tunel na bastion a namapují se porty. Není to nijak zvlášť elegantní, ale konečně to funguje. 😕  Na víc už asi nemám síly. 😅 

To mapování bude např. [v případě orders](https://github.com/FigurePOS/fgr-service-orders/blob/52d2772aab8e494aba27580ac960da0480339f45/tf/scripts/deploy.sh#L26-L33) vypadat takto: `db_tunnel_mapping: 5432:main_database_host,5433:service.orders.reports_postgres_endpoint`

---

FYI. Původně jsem se snažil o nadefinování ssh tunelu v terraformu což vypadalo krásně:

![CleanShot 2023-09-01 at 17 19 53](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/bb56497d-65ac-401d-b484-32cd4404925d)

a fungovalo mi to (s jedním drobným omezením že by se deploy musel udělat najednou a nešel by v jednom kroku vytvořit plánu a následně ho aplikovat). Jenže jsem to za žádnou cenu nerozjel v Circle CI. Failovalo to bez chybových zpráv a po delší době debuggingu jsem to vzdal. 