### PR TITLE
fix: docker layer caching FGR3-2576

### DIFF
--- a/src/commands/push_image.yml
+++ b/src/commands/push_image.yml
@@ -15,8 +15,6 @@ parameters:
     default: "637192944017.dkr.ecr.us-east-1.amazonaws.com"
 
 steps:
-  - setup_remote_docker:
-      docker_layer_caching: true
   - run:
       name: Push image
       environment:


### PR DESCRIPTION
V pushi se volá `load_image` a po něm `push_image`
![CleanShot 2023-10-23 at 11 29 09](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/fac65f91-7045-4626-ba9c-517b855e5e5b)

A Circlu se nelíbí že v obou se setupuje docker:
![image](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/e78323a4-1123-41eb-a811-2bd4d645601e)

Odstranil jsem to z `push` jobu, protože on sám od sebe stejně nefunguje, potřebuje mít k dispozici buildnutý image a tím pádem i setupnutý docker. Snad to dává smysl. Přemýšlel jsem i nad možností spojit load a push dohromady (load dělá to že image vezme z workflow Circlu (kam ho uloží `build` job) a naloaduje ho zpátky do dockeru: https://github.com/FigurePOS/circle-ci-terraform-orb/blob/1fea40a612a363cdc26dcc3fdb691a65a61163b5/src/commands/load_image.yml#L12), ale už se mi to moc nelíbí, navíc load potřebují i některý ty e2e testy.