### PR TITLE
feat: add yarn build command FGR3-2576

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,5 +8,6 @@ display:
 
 orbs:
   continuation: circleci/continuation@1.0.0
+  node: circleci/node@5.1.0
   path-filtering: circleci/path-filtering@1.0.0
   slack: circleci/slack@4.12.5

--- a/src/commands/yarn_build.yml
+++ b/src/commands/yarn_build.yml
@@ -1,0 +1,16 @@
+description: >
+  Run `yarn build` with caching node_modules.
+
+steps:
+  - restore_cache:
+      key: build-yarn-deps-{{ checksum "yarn.lock" }}
+  - node/install-packages:
+      pkg-manager: yarn
+      with-cache: false
+  - save_cache:
+      key: build-yarn-deps-{{ checksum "yarn.lock" }}
+      paths:
+        - node_modules
+  - run:
+      name: "Yarn build"
+      command: yarn build

--- a/src/commands/yarn_build.yml
+++ b/src/commands/yarn_build.yml
@@ -3,12 +3,12 @@ description: >
 
 steps:
   - restore_cache:
-      key: build-yarn-deps-{{ checksum "yarn.lock" }}
+      key: build-dev-yarn-deps-{{ checksum "yarn.lock" }}
   - node/install-packages:
       pkg-manager: yarn
       with-cache: false
   - save_cache:
-      key: build-yarn-deps-{{ checksum "yarn.lock" }}
+      key: build-dev-yarn-deps-{{ checksum "yarn.lock" }}
       paths:
         - node_modules
   - run:

--- a/src/commands/yarn_build_image.yml
+++ b/src/commands/yarn_build_image.yml
@@ -12,9 +12,15 @@ parameters:
 
 steps:
   - yarn_build
+  - restore_cache:
+      key: build-prod-yarn-deps-{{ checksum "yarn.lock" }}
   - run:
       name: "Yarn install production dependencies"
       command: yarn install --prod --pure-lockfile
+  - save_cache:
+      key: build-prod-yarn-deps-{{ checksum "yarn.lock" }}
+      paths:
+        - node_modules
   - build_image:
       repository_name: <<parameters.repository_name>>
       repository_url: <<parameters.repository_url>>

--- a/src/commands/yarn_build_image.yml
+++ b/src/commands/yarn_build_image.yml
@@ -1,0 +1,20 @@
+description: >
+  Run `yarn build`, build docker image and store it in workspace.
+
+parameters:
+  repository_name:
+    type: string
+    description: "Docker repository name"
+  repository_url:
+    type: string
+    description: "Docker repository URL"
+    default: "637192944017.dkr.ecr.us-east-1.amazonaws.com"
+
+steps:
+  - yarn_build
+  - run:
+      name: "Yarn install production dependencies"
+      command: yarn install --prod --pure-lockfile
+  - build_image:
+      repository_name: <<parameters.repository_name>>
+      repository_url: <<parameters.repository_url>>


### PR DESCRIPTION
`yarn_build` command je zkratka pro `yarn install` a `yarn build`, tuhle část: https://github.com/FigurePOS/fgr-service-business-config/blob/master/.circleci/app.yml#L20-L26

`yarn_build_image` je zkratka včetně `yarn install --prod --pure-lockfile` a `node-ecs/build_image` (tj. tahle část: https://github.com/FigurePOS/fgr-service-business-config/blob/de32a13afc75048f79d5c55b65e9bb271329b062/.circleci/app.yml#L20-L29) - Tím se zkrátí zápis build jobu téměř ve všech servisách (kromě javy a manage frontendu, který to maj jinak.)

Ale hlavně proč jsem se do toho vůbec pustil a proč tady používám `restore_cache` a `save_cache`.. 
Tenhle postup buildu nefungoval korektně:
```
            - node/install-packages:
                  pkg-manager: yarn
                  with-cache: true
            - run:
                  name: "Yarn build and install"
                  command: |
                      yarn build
                      yarn install --prod --pure-lockfile
```

Čekal bych že se provede `yarn install` s dev dependencies, potom se node_modules uloží do cache, spustí se `yarn build` a potom se provede `yarn install` pro produkci (který se uloží do docker image).

Ta cache se ale zjevně ukládá až na konci celýho jobu, protože se do ní uloží jen produkční package. Přišli jsme na to tak, že začaly v business configu failovat e2e testy na chybějících dev dependencies:

![CleanShot 2023-11-02 at 19 51 37@2x](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/c8650b38-bd35-4581-98b7-5af51d7d183d)

Node package se restorovaly z CI jobu 8740, což byl právě `build` job:

![CleanShot 2023-11-02 at 19 55 28@2x](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/cbca2cb2-1f47-4f58-af58-b1e1cc145f80)

Takže to fixuju tak, že  v commandu `node/install-packages` vypnu cachování pomocí `with-cache: false` a dělám manuální ukládání a restore cache jen pro tenhle job.