### PR TITLE
fix: deploy prod job dependency FGR3-2576

### DIFF
--- a/workflows/deploy-app-tf.yml
+++ b/workflows/deploy-app-tf.yml
@@ -71,6 +71,7 @@ workflows:
       - approve_deploy_prod:
           type: approval
           requires:
+            - push
             - terraform_plan_prod
           filters:
             branches:


### PR DESCRIPTION
V TF workflow je ještě jeden bug, a to že deploy aplikace do produkce nemusí čekat na push image. Dávám závislost už na approve terraformu, protože imho pokud náhodou vyfailuje push image, tak je lepší raději nedeployovat ani infra.

![CleanShot 2023-11-07 at 09 46 56@2x](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/132ee236-8dcf-42d1-841f-64d667ba3117)
