### PR TITLE
feat: add load docker image command for machine executors FGR3-3032

### DIFF
--- a/src/commands/load_image_machine.yml
+++ b/src/commands/load_image_machine.yml
@@ -1,0 +1,10 @@
+description: >
+  Load docker image from workspace on machine executor.
+
+steps:
+  - attach_workspace:
+      at: .
+  - run:
+      name: Load image
+      command: |
+        docker image load < "images/${CIRCLE_SHA1}"


### PR DESCRIPTION
Uf, tak jsem horko těžko překonal zase jednu perličku Circle CI.

V https://github.com/FigurePOS/fgr-service-delivery/pull/180/files potřebuju přidat ten load docker image do e2e testů, aby se mohly spustit s lokálně buildnutým imagem. Jenže ten job e2e testů není docker executor, ale machine executor:
<img width="391" alt="image" src="https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/6f730ea3-6d18-421b-9a36-85f49416725f">
A u toho nejde použít tady ten náš `load_image` command, protože je v něm `setup_remote_docker` step (https://github.com/FigurePOS/circle-ci-node-ecs-orb/blob/master/src/commands/load_image.yml) který v machine executoru nemůže být:
![CleanShot 2023-11-29 at 19 30 03@2x](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/f27a3120-3bda-4add-85c7-3c90c9f1a5e5)

Bohužel spouštět e2e testy (resp. konkrétně docker compose) na docker executoru moc dobře nejde, nefunguje tam volume mounting (https://circleci.com/docs/docker-compose/#using-docker-compose-with-docker-executor), což mi chvíli trvalo zjistit. 🙄 Tak přidávám další extra command `load_image_machine` který se bude používat jen na machine executorech. 