### PR TITLE
fix: do not push to ECR if the same image already exists FGR3-3254

### DIFF
--- a/src/commands/push_image.yml
+++ b/src/commands/push_image.yml
@@ -22,9 +22,16 @@ steps:
         REPOSITORY_NAME: <<parameters.repository_name>>
         REPOSITORY_URL: <<parameters.repository_url>>
       command: |
+        IMAGE_TAG="${CIRCLE_SHA1:0:7}"
         aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$REPOSITORY_URL"
-        docker push "$REPOSITORY_URL/$REPOSITORY_NAME:${CIRCLE_SHA1:0:7}"
 
-        MANIFEST=$(aws ecr batch-get-image --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --image-ids imageTag="${CIRCLE_SHA1:0:7}" --query 'images[].imageManifest' --output text)
+        IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$REPOSITORY_URL/$REPOSITORY_NAME:$IMAGE_TAG")
+        IMAGE_EXISTS=$(aws ecr describe-images --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --filter "tagStatus=TAGGED" --query "imageDetails[?imageDigest=='${IMAGE_DIGEST#*@}']" --output text)
+        if [ -z "$IMAGE_EXISTS" ]; then
+          docker push "$REPOSITORY_URL/$REPOSITORY_NAME:$IMAGE_TAG"
+        else
+          echo "Image with the same digest already exists in the ECR. Skipping push."
+        fi
 
+        MANIFEST=$(aws ecr batch-get-image --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --image-ids imageTag="$IMAGE_TAG" --query 'images[].imageManifest' --output text)
         aws ecr put-image --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --image-tag "latest" --image-manifest "$MANIFEST"


### PR DESCRIPTION
Když se mergne do masteru úprava která nezmění buildnutý image, tak vyfailuje push do ECR protože image se stejným digestem už existuje (stalo se např. po tomhle mergi: https://github.com/FigurePOS/make-it-butter-api/commit/9998457aaa667fcf1045273e95a06fc9a5173f46):
![image](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/ce9f487a-29fd-46be-be36-5906c93f2e7a)

(Je teda trochu zvláštní že když se upravuje jen terraform, tak se to nestane. 🤔, např. tady https://github.com/FigurePOS/make-it-butter-api/commit/b0f40eab67d0b5b7d95ce08678449ccdc63b4221 push normálně proběhl: https://app.circleci.com/pipelines/github/FigurePOS/make-it-butter-api/2767/workflows/12e0debf-f91d-4a66-b3e6-b43fb8f6c959/jobs/8613 🤔 Počkat počkat, tak to určitě buildujeme do image i terraform skripty. 😅 Fixnu.)

No, nicméně řešení je teda zkontrolovat jestli image se stejným digestem v ECR už není a pokud jo, tak přeskočit push. Jen otagovat ten image novým tagem. Tady jsem to postupně vyzkoušel:
![CleanShot 2024-01-26 at 10 50 39](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/b751436d-4dfe-452e-87f8-fe7b5374cfe6)

