### PR TITLE
fix: do not push to ECR if the same image already exists FGR3-3254

### DIFF
--- a/src/commands/push_image.yml
+++ b/src/commands/push_image.yml
@@ -21,17 +21,4 @@ steps:
         AWS_REGION: <<parameters.aws_region>>
         REPOSITORY_NAME: <<parameters.repository_name>>
         REPOSITORY_URL: <<parameters.repository_url>>
-      command: |
-        IMAGE_TAG="${CIRCLE_SHA1:0:7}"
-        aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$REPOSITORY_URL"
-
-        IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$REPOSITORY_URL/$REPOSITORY_NAME:$IMAGE_TAG")
-        IMAGE_EXISTS=$(aws ecr describe-images --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --filter "tagStatus=TAGGED" --query "imageDetails[?imageDigest=='${IMAGE_DIGEST#*@}']" --output text)
-        if [ -z "$IMAGE_EXISTS" ]; then
-          docker push "$REPOSITORY_URL/$REPOSITORY_NAME:$IMAGE_TAG"
-        else
-          echo "Image with the same digest already exists in the ECR. Skipping push."
-        fi
-
-        MANIFEST=$(aws ecr batch-get-image --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --image-ids imageTag="$IMAGE_TAG" --query 'images[].imageManifest' --output text)
-        aws ecr put-image --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --image-tag "latest" --image-manifest "$MANIFEST"
+      command: <<include(scripts/push-image.sh)>>

--- a/src/scripts/push-image.sh
+++ b/src/scripts/push-image.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+IMAGE_TAG="${CIRCLE_SHA1:0:7}"
+aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$REPOSITORY_URL"
+
+docker push "$REPOSITORY_URL/$REPOSITORY_NAME:${IMAGE_TAG}"
+
+MANIFEST=$(aws ecr batch-get-image --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --image-ids imageTag="$IMAGE_TAG" --query 'images[].imageManifest' --output text)
+
+# Check if the image with tags "latest" and "$IMAGE_TAG" already exists
+if aws ecr describe-images --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --image-ids imageTag="latest" imageTag="$IMAGE_TAG" --query 'imageDetails' --output json | jq --arg IMAGE_TAG "$IMAGE_TAG" '.[] | select(.imageTags | contains(["latest", $IMAGE_TAG]))'; then
+  echo "Image with tags 'latest' and '$IMAGE_TAG' already exists in the registry."
+else
+  aws ecr put-image --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --image-tag "latest" --image-manifest "$MANIFEST"
+fi


### PR DESCRIPTION
No, tak tohle nefungovalo: https://github.com/FigurePOS/circle-ci-node-ecs-orb/pull/47 😄 

Za prvé je problém v tom že lokálně zbuildnutý image nemá digest manifestu (tj. `docker inspect` nevrátí žádný `RepoDigests`), takže tento command vyfailuje: https://github.com/FigurePOS/circle-ci-node-ecs-orb/blob/395e2f9e7bce3e1041eb85f2814c230f0e56f908/src/commands/push_image.yml#L28

![CleanShot 2024-01-29 at 10 55 24](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/649806b1-9b44-4ce1-95c4-4088878b4e20)

Viz. https://stackoverflow.com/a/39812035

---

A za druhé problém nebyl v `docker push` commandu, ale až v tom posledním `aws ecr put-image`, který přesune tag `latest` na nově pushnutý image s tagem `$IMAGE_TAG`. Jsem si tu chybu blbě přečetl. 🙄
![CleanShot 2024-01-29 at 11 00 56](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/252048b5-eaca-4e49-a507-885054b696cc)

---

No a ten problém teda byl že pokud se v posledním mergi nic nezměnilo v kódu servisy, tak se tagem `$IMAGE_TAG` otagoval image předchozího releasu a tag `latest` se měl přesunout na ten samý image. Což vyfailovalo.

Příklad z toho Butteru. Předchozí release byl `f04d7e4`, takže poslední image měl tagy `f04d7e4` a `latest`. Můj release nic nezměnil v kódu, takže `docker push` pushnul pod tagem `9998457` image se stejným digestem, což ve výsledku udělalo jen to, že se k tomu už existujícímu imagi přidal tag `9998457` (viz. obr.). 

![CleanShot 2024-01-29 at 11 02 46](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/f7130d3b-f622-4adb-910f-189ac21df93a)

---

No a tenhle fix funguje tak že se zavolá `aws ecr describe-images` pro tagy `latest` a `$IMAGE_TAG` a pokud jsou oba tagy u jednoho image, tak se `aws ecr put-image` přeskočí. 

Příklad z message-routeru, poslední image má tag `latest` a `3aa0713`, takže když ten command zavolám se stejným tagem `3aa0713` (tj. kód servisy se nezměnil), tak vrátí json, tj. provede se `then` v `ifu`. Když ho zavolám s jiným tagem - na příkladu mám `3e2a7cd` který sice v repu už je, ale není `latest`- tzn. že se provedl `docker push` image s jiným digestem. Takže se provede `else` s `put-image`, který přesune `latest` tag z prvního image na druhý.

Je to srozumitelný? 😬 

![CleanShot 2024-01-29 at 11 14 33](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/53e22bd3-0658-49cc-8aae-2cca928ea87b)

