### PR TITLE
fix: do not push to ECR if the same image already exists, vol. 3 FGR3-3367

### DIFF
--- a/src/scripts/push-image.sh
+++ b/src/scripts/push-image.sh
@@ -8,7 +8,7 @@ docker push "$REPOSITORY_URL/$REPOSITORY_NAME:${IMAGE_TAG}"
 MANIFEST=$(aws ecr batch-get-image --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --image-ids imageTag="$IMAGE_TAG" --query 'images[].imageManifest' --output text)
 
 # Check if the image with tags "latest" and "$IMAGE_TAG" already exists
-if aws ecr describe-images --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --image-ids imageTag="latest" imageTag="$IMAGE_TAG" --query 'imageDetails' --output json | jq --arg IMAGE_TAG "$IMAGE_TAG" '.[] | select(.imageTags | contains(["latest", $IMAGE_TAG]))'; then
+if [ -n "$(aws ecr describe-images --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --image-ids imageTag="latest" imageTag="$IMAGE_TAG" --query 'imageDetails' --output json | jq --arg IMAGE_TAG "$IMAGE_TAG" '.[] | select(.imageTags | contains(["latest", $IMAGE_TAG]))')" ]; then
   echo "Image with tags 'latest' and '$IMAGE_TAG' already exists in the registry."
 else
   aws ecr put-image --region "$AWS_REGION" --repository-name "$REPOSITORY_NAME" --image-tag "latest" --image-manifest "$MANIFEST"


### PR DESCRIPTION
Tak skoro, moc jsem věřil Copilotovi. 🙈 Ten if vracel `true` pokud byl exit kód `1`, já potřebuju aby vracel `true` jen když má ten command něco na stdout.

Teď už to snad bude ono:
![CleanShot 2024-01-29 at 13 25 43](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/b91462aa-4fba-4531-b9db-b83978b98be6)

![CleanShot 2024-01-29 at 13 27 28](https://github.com/FigurePOS/circle-ci-node-ecs-orb/assets/215660/bab0d11d-7768-4158-afa9-267591a5fde9)
