### PR TITLE
fix: do not create new comments with tf plan on every push FGR3-2215

### DIFF
--- a/src/scripts/terraform-plan.sh
+++ b/src/scripts/terraform-plan.sh
@@ -76,7 +76,7 @@ github-commenter \
     -owner "${CIRCLE_PROJECT_USERNAME}" \
     -repo "${CIRCLE_PROJECT_REPONAME}" \
     -number "$CIRCLE_PR_NUMBER" \
-    -delete-comment-regex "Output from \*\*${ENV}\*\*" \
+    -edit-comment-regex "Output from \*\*${ENV}\*\* \`terraform plan\`" \
     -type pr \
     -template "$COMMENT_TPL" < /tmp/"$ENV"-plan.txt
 


### PR DESCRIPTION
Po každým pushi do PR se smazal komentář s TF plánem a vytvořil se nový. To jsem změnil tak, aby se vytvořil jen jednou a potom jen upravoval (podle https://github.com/cloudposse/github-commenter?tab=readme-ov-file#usage).